### PR TITLE
parse contents, not name, of environment variable

### DIFF
--- a/requestbuilder/mixins/__init__.py
+++ b/requestbuilder/mixins/__init__.py
@@ -52,7 +52,7 @@ class RegionConfigurableMixin(object):
                     break
         elif isinstance(region_envvar, six.string_types):
             if os.getenv(region_envvar):
-                _user, _region = self.__parse_region(region_envvar)
+                _user, _region = self.__parse_region(os.getenv(region_envvar))
                 user = user or _user
                 region = region or _region
         # Default region from the config file


### PR DESCRIPTION
fix to parse contents, and not name, of environment variable for default region
(e.g. "AWS_DEFAULT_REGION" of euca2ools)
